### PR TITLE
Use HTTP transfer protocol instead of FTP to download the unicodedata…

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -5,7 +5,7 @@ using StrTables
 const VER = UInt32(1)
 
 const datapath = joinpath(Pkg.dir(), "Unicode_Entities", "data")
-const dpath = "ftp://ftp.unicode.org/Public/UNIDATA/"
+const dpath = "http://ftp.unicode.org/Public/UNIDATA/"
 const fname = "UnicodeData.txt"
 const disp = [false]
 


### PR DESCRIPTION
… file.

In secured environments http is more supported for outgoing connections that ftp.